### PR TITLE
Fix failing Travis CI: use compatible versions of git and musl-dev with alpine3.8

### DIFF
--- a/services/yfuzz-server/Dockerfile
+++ b/services/yfuzz-server/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-RUN apk --no-cache add git=2.18.0-r0 glide=0.13.1-r0 make=4.2.1-r2
+RUN apk --no-cache add git=2.18.1-r0 glide=0.13.1-r0 make=4.2.1-r2 musl-dev=1.1.19-r10
 COPY services /go/src/github.com/yahoo/yfuzz/services
 COPY pkg /go/src/github.com/yahoo/yfuzz/pkg
 COPY scripts /go/src/github.com/yahoo/yfuzz/scripts


### PR DESCRIPTION
This PR should hopefully fix Travis CI failures